### PR TITLE
use requests

### DIFF
--- a/Lecture.ipynb
+++ b/Lecture.ipynb
@@ -843,21 +843,24 @@
     "**Bonus**: Adding NYC map underneath!\n",
     "\n",
     "```python\n",
-    "import urllib\n",
-    "i = urllib.request.urlopen('https://upload.wikimedia.org/wikipedia/commons/e/ec/Neighbourhoods_New_York_City_Map.PNG')\n",
-    "plt.imshow(plt.imread(i), zorder=0, extent=[-74.258, -73.7, 40.49, 40.92])\n",
+    "import requests\n",
+    "from PIL import Image\n",
+    "url ='https://upload.wikimedia.org/wikipedia/commons/e/ec/Neighbourhoods_New_York_City_Map.PNG'\n",
+    "im = Image.open(requests.get(url, stream=True).raw)\n",
+    "plt.imshow(im, zorder=0, extent=[-74.258, -73.7, 40.49, 40.92])\n",
     "ax = plt.gca()\n",
     "affordable_df.plot(\n",
-    "    ax=ax,\n",
-    "    zorder=1,\n",
-    "    kind='scatter',\n",
-    "    x='longitude',\n",
-    "    y='latitude',\n",
-    "    c='price',\n",
-    "    cmap='inferno',\n",
-    "    colorbar=True,\n",
-    "    alpha=0.8,\n",
-    "    figsize=(12,8))\n",
+    "  ax=ax,\n",
+    "  zorder=1,\n",
+    "  kind='scatter',\n",
+    "  x='longitude',\n",
+    "  y='latitude',\n",
+    "  c='price',\n",
+    "  cmap='inferno',\n",
+    "  colorbar=True,\n",
+    "  alpha=0.8,\n",
+    "  figsize=(12,8)\n",
+    ")\n",
     "```"
    ]
   },
@@ -992,7 +995,49 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.5"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
this fixes `UnsupportedOperation: seek` error on slide https://learn.lewagon.com/pdf_slide_decks/285/file#/4/10:
- deleted:
```python
import urllib
i = urllib.request.urlopen('https://upload.wikimedia.org/wikipedia/commons/e/ec/Neighbourhoods_New_York_City_Map.PNG')
plt.imshow(plt.imread(i), zorder=0, extent=[-74.258, -73.7, 40.49, 40.92])
ax = plt.gca()
affordable_df.plot(
  ax=ax,
  zorder=1,
  kind='scatter',
  x='longitude',
  y='latitude',
  c='price',
  cmap='inferno',
  colorbar=True,
  alpha=0.8,
  figsize=(12,8))
```
- added:
```python 
import requests
from PIL import Image
url ='https://upload.wikimedia.org/wikipedia/commons/e/ec/Neighbourhoods_New_York_City_Map.PNG'
im = Image.open(requests.get(url, stream=True).raw)
plt.imshow(im, zorder=0, extent=[-74.258, -73.7, 40.49, 40.92])
ax = plt.gca()
affordable_df.plot(
  ax=ax,
  zorder=1,
  kind='scatter',
  x='longitude',
  y='latitude',
  c='price',
  cmap='inferno',
  colorbar=True,
  alpha=0.8,
  figsize=(12,8))
```
@Eschults the slides should be changed on Learn after merging